### PR TITLE
Docs: Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,36 +1,23 @@
-# This template CITATION.cff file was generated with cffinit.
-# Visit https://bit.ly/cffinit to replace its contents
-# with information about your lesson.
-# Remember to update this file periodically, 
-# ensuring that the author list and other fields remain accurate.
-
 cff-version: 1.2.0
-title: Open Researcher and Contributor IDs (ORCID) for Librarians
-message: >-
-  Please cite this lesson using the information in this file
-  when you refer to it in publications, and/or if you
-  re-use, adapt, or expand on the content in your own
-  training material.
+message: "If you use this lesson, please cite it as below."
 type: dataset
+title: "Leveraging Open Research and Contributor IDs (ORCID) for Librarians"
 authors:
-  - given-names: Levi
-    family-names: Dolan
-    email: dolanl@iu.edu
-    affiliation: Indiana University School of Medicine
-    orcid: 'https://orcid.org/0000-0002-5599-4909'
-  - given-names: Mirian
-    family-names: Ramirez
-    email: mirirami@iu.edu
-    affiliation: Indiana University School of Medicine
-    orcid: 'https://orcid.org/0000-0002-6233-7480'
-  - given-names: 'Hannah J.'
-    family-names: Craven
-    email: hancrave@iu.edu
-    affiliation: Indiana University School of Medicine
-    orcid: 'https://orcid.org/0000-0002-1701-3655'
-abstract: >-
-  This lesson introduces how to create an ORCID, the problem that ORCID is seeking to solve by describing how 
-  persistent researcher IDs support open science concepts,especially in making data Findable, Accessible,
-  Interoperable, and Reusable (FAIR), and how to connect an ORCID record to systems that will automatically 
-  populate the record.
+  - family-names: Dolan
+    given-names: Levi
+  - family-names: Ramirez
+    given-names: Mirian
+    orcid: "https://orcid.org/0000-0002-6233-7480"
+  - family-names: Craven
+    given-names: Hannah
+abstract: "Guides learners through creating an ORCID, understanding its significance, and connecting it to major systems that update ORCID records."
+keywords:
+  - ORCID
+  - identifiers
+  - researcher profiles
+  - metadata
 license: CC-BY-4.0
+version: 1.0.0
+date-released: 2026-01-06
+repository-code: "https://github.com/firbolg/LC_ORCID"
+url: "https://firbolg.github.io/LC_ORCID/"


### PR DESCRIPTION
This PR adds a CITATION.cff file to make the lesson citable, generated from the IMLS Open Science project metadata.